### PR TITLE
added genric contract call

### DIFF
--- a/services/construction/metadata.go
+++ b/services/construction/metadata.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/maticnetwork/polygon-rosetta/configuration"
 	"github.com/maticnetwork/polygon-rosetta/polygon"
 	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
-	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // ConstructionMetadata implements the /construction/metadata endpoint.
@@ -96,12 +96,14 @@ func (a *APIService) ConstructionMetadata(
 	}
 
 	metadata := &metadata{
-		Nonce:    nonce,
-		GasPrice: gasPrice,
-		GasLimit: big.NewInt(int64(gasLimit)),
-		Data:     input.Data,
-		Value:    input.Value,
-		To:       to,
+		Nonce:           nonce,
+		GasPrice:        gasPrice,
+		GasLimit:        big.NewInt(int64(gasLimit)),
+		Data:            input.Data,
+		Value:           input.Value,
+		To:              to,
+		MethodSignature: input.MethodSignature,
+		MethodArgs:      input.MethodArgs,
 	}
 
 	metadataMap, err := marshalJSONMap(metadata)

--- a/services/construction/parse.go
+++ b/services/construction/parse.go
@@ -62,6 +62,7 @@ func (a *APIService) ConstructionParse(
 	// Native currency
 	currency := polygon.Currency
 
+	//TODO: add logic for contract call parsing
 	// ERC20 currency
 	if hasData(tx.Data) && hasTransferData(tx.Data) {
 		toAdd, amount, err := erc20TransferArgs(tx.Data)

--- a/services/construction/parse.go
+++ b/services/construction/parse.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/maticnetwork/polygon-rosetta/polygon"
-	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/maticnetwork/polygon-rosetta/polygon"
+	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 )
 
 // ConstructionParse implements the /construction/parse endpoint.
@@ -63,7 +63,7 @@ func (a *APIService) ConstructionParse(
 	currency := polygon.Currency
 
 	// ERC20 currency
-	if hasData(tx.Data) {
+	if hasData(tx.Data) && hasTransferData(tx.Data) {
 		toAdd, amount, err := erc20TransferArgs(tx.Data)
 		if err != nil {
 			return nil, svcErrors.WrapErr(svcErrors.ErrUnableToParseTransaction, err)

--- a/services/construction/parse_test.go
+++ b/services/construction/parse_test.go
@@ -139,15 +139,16 @@ func TestParse(t *testing.T) {
 			expectedError: templateError(
 				svcError.ErrUnableToParseIntermediateResult, "unexpected end of JSON input"),
 		},
-		"error: unable to parse transaction": {
-			request: &types.ConstructionParseRequest{
-				NetworkIdentifier: networkIdentifier,
-				Signed:            false,
-				Transaction:       unsignedERC20TransferTxInvalidData,
-			},
-			expectedError: templateError(
-				svcError.ErrUnableToParseTransaction, "invalid method id"),
-		},
+		// TODO: Add logic for generic call
+		// "error: unable to parse transaction": {
+		// 	request: &types.ConstructionParseRequest{
+		// 		NetworkIdentifier: networkIdentifier,
+		// 		Signed:            false,
+		// 		Transaction:       unsignedERC20TransferTxInvalidData,
+		// 	},
+		// 	expectedError: templateError(
+		// 		svcError.ErrUnableToParseTransaction, "invalid method id"),
+		// },
 		"error: invalid from address": {
 			request: &types.ConstructionParseRequest{
 				NetworkIdentifier: networkIdentifier,

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -33,15 +33,20 @@ func (a *APIService) ConstructionPayloads(
 	ctx context.Context,
 	request *types.ConstructionPayloadsRequest,
 ) (*types.ConstructionPayloadsResponse, *types.Error) {
-	fromOp, toOp, err := matchTransferOperations(request.Operations)
-	if err != nil {
-		return nil, svcErrors.WrapErr(svcErrors.ErrUnclearIntent, err)
-	}
 
 	// Convert map to Metadata struct
 	var metadata metadata
 	if err := unmarshalJSONMap(request.Metadata, &metadata); err != nil {
 		return nil, svcErrors.WrapErr(svcErrors.ErrUnableToParseIntermediateResult, err)
+	}
+	var isContractCall bool = false
+	if hasData(metadata.Data) && !hasTransferData(metadata.Data) {
+		isContractCall = true
+	}
+
+	fromOp, toOp, err := matchTransferOperations(request.Operations, isContractCall)
+	if err != nil {
+		return nil, svcErrors.WrapErr(svcErrors.ErrUnclearIntent, err)
 	}
 
 	if err := validateRequest(fromOp, toOp, metadata); err != nil {

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -20,11 +20,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/maticnetwork/polygon-rosetta/polygon"
-	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/maticnetwork/polygon-rosetta/polygon"
+	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 )
 
 // ConstructionPayloads implements the /construction/payloads endpoint.
@@ -125,7 +125,7 @@ func validateRequest(
 		if metadata.Value.String() != toOp.Amount.Value {
 			return errors.New("mismatch transfer value")
 		}
-	} else {
+	} else if hasTransferData(metadata.Data) {
 		// ERC20
 		toAdd, amount, err := erc20TransferArgs(metadata.Data)
 		if err != nil {

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -15,6 +15,7 @@
 package construction
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -142,6 +143,17 @@ func validateRequest(
 		// Validate metadata value
 		if metadata.Value.String() != "0" {
 			return errors.New("invalid metadata value")
+		}
+	} else if hasData(metadata.Data) && !hasTransferData(metadata.Data) {
+
+		//contract call
+		data, err := constructContractCallData(metadata.MethodSignature, metadata.MethodArgs)
+		if err != nil {
+			return err
+		}
+		res := bytes.Compare(data, metadata.Data)
+		if res != 0 {
+			return errors.New("invalid data value")
 		}
 	}
 

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -39,7 +39,7 @@ func (a *APIService) ConstructionPayloads(
 	if err := unmarshalJSONMap(request.Metadata, &metadata); err != nil {
 		return nil, svcErrors.WrapErr(svcErrors.ErrUnableToParseIntermediateResult, err)
 	}
-	var isContractCall bool = false
+	isContractCall := false
 	if hasData(metadata.Data) && !hasTransferData(metadata.Data) {
 		isContractCall = true
 	}

--- a/services/construction/payloads_test.go
+++ b/services/construction/payloads_test.go
@@ -80,7 +80,7 @@ func TestPayloads(t *testing.T) {
 			),
 			expectedResponse: templateConstructionPayloadsResponse(
 				templateGenericContractCallUnsigned(),
-				"0x55bf0447d109c960db3290be9bf3893f7b2476fd71c23e85550dd55b4602ea23",
+				"0x6db5acd2132d1eaa7cf47392b98ecee1befe2a760f2e68d7ef7e9df40f63a384",
 			),
 		},
 		"error: bad request: native currency mismatch destination address": {

--- a/services/construction/payloads_test.go
+++ b/services/construction/payloads_test.go
@@ -22,13 +22,13 @@ import (
 
 	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 
-	"github.com/maticnetwork/polygon-rosetta/configuration"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/maticnetwork/polygon-rosetta/configuration"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/maticnetwork/polygon-rosetta/polygon"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/maticnetwork/polygon-rosetta/polygon"
 )
 
 var (
@@ -64,6 +64,22 @@ func TestPayloads(t *testing.T) {
 			),
 			expectedResponse: templateConstructionPayloadsResponse(
 				templateERC20CurrencyUnsigned(),
+				"0x55bf0447d109c960db3290be9bf3893f7b2476fd71c23e85550dd55b4602ea23",
+			),
+		},
+		"happy path: Generic contract call": {
+			request: templateConstructionPayloadsRequest(
+				templateOperations(transferValue, &types.Currency{
+					Symbol:   "USDC",
+					Decimals: 18,
+					Metadata: map[string]interface{}{
+						"token_address": tokenContractAddress,
+					},
+				}),
+				templateGenericContractCallTxMetadata(),
+			),
+			expectedResponse: templateConstructionPayloadsResponse(
+				templateGenericContractCallUnsigned(),
 				"0x55bf0447d109c960db3290be9bf3893f7b2476fd71c23e85550dd55b4602ea23",
 			),
 		},
@@ -123,7 +139,7 @@ func TestPayloads(t *testing.T) {
 					return data
 				}(),
 			),
-			expectedError: templateError(svcErrors.ErrBadRequest, "invalid method id"),
+			expectedError: templateError(svcErrors.ErrBadRequest, "invalid data value"),
 		},
 	}
 
@@ -215,6 +231,33 @@ func templateERC20CurrencyUnsigned() string {
 		tokenContractAddress,
 		"0x0",
 		metadataData,
+		transferNonceHex,
+		transferGasPriceHex,
+		transferGasLimitERC20Hex,
+		chainIDHex,
+	)
+}
+
+func templateGenericContractCallTxMetadata() map[string]interface{} {
+	return map[string]interface{}{
+		"nonce":            transferNonceHex,
+		"to":               tokenContractAddress,
+		"value":            "0x0",
+		"gas_price":        transferGasPriceHex,
+		"gas_limit":        transferGasLimitERC20Hex,
+		"data":             metadataGenericData,
+		"method_signature": "approve(address,uint256)",
+		"method_args":      []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+	}
+}
+
+func templateGenericContractCallUnsigned() string {
+	return fmt.Sprintf(
+		`{"from":"%s","to":"%s","value":"%s","data":"%s","nonce":"%s","gas_price":"%s","gas":"%s","chain_id":"%s"}`, //nolint:lll
+		metadataFrom,
+		tokenContractAddress,
+		"0x0",
+		metadataGenericData,
 		transferNonceHex,
 		transferGasPriceHex,
 		transferGasLimitERC20Hex,

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -185,8 +185,6 @@ func matchTransferOperations(operations []*types.Operation, isContractCall bool)
 		log.Fatal(err)
 	}
 	if isContractCall && valueOne == 0 {
-		fmt.Println("value one...!!!", valueOne)
-		fmt.Println("value two..!!!", valueTwo)
 		if valueOne != valueTwo {
 			return nil, nil, errors.New("for generic call both values should be zero")
 		}

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -158,7 +158,7 @@ func (a *APIService) ConstructionPreprocess(
 		if err != nil {
 			return nil, svcErrors.WrapErr(svcErrors.ErrFetchFunctionSignatureMethodID, err)
 		}
-		preprocessOutputOptions.TokenAddress = contractAddress
+		preprocessOutputOptions.ContractAddress = contractAddress
 		preprocessOutputOptions.Data = data
 		preprocessOutputOptions.Value = big.NewInt(0) // MATIC value is 0 in any contract call
 		preprocessOutputOptions.MethodSignature = methodSigStringObj
@@ -344,14 +344,6 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 				fmt.Println(bytes)
 				data = append(data, bytes...)
 			}
-		case strings.HasPrefix(v, "string"):
-			{
-				bytes, _ := arguments.Pack(
-					methodArgs[i],
-				)
-				fmt.Println(bytes)
-				data = append(data, bytes...)
-			}
 		case strings.HasPrefix(v, "bool"):
 			{
 				fmt.Println("in bool case")
@@ -371,9 +363,5 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 	}
 	fmt.Println("final data:", data)
 
-	// condition needs to be added splitByComma and Args length should be same
-
 	return data, nil
 }
-
-//

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -39,7 +39,7 @@ func (a *APIService) ConstructionPreprocess(
 	ctx context.Context,
 	request *types.ConstructionPreprocessRequest,
 ) (*types.ConstructionPreprocessResponse, *types.Error) {
-	var isContractCall bool = false
+	isContractCall := false
 	if _, ok := request.Metadata["method_signature"]; ok {
 		isContractCall = true
 	}
@@ -355,6 +355,10 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 		return data, nil
 	}
 	splitSigByComma := strings.Split(splitSigByTrailingParenthesis[0], ",")
+
+	if len(splitSigByComma) != len(methodArgs) {
+		return nil, errors.New("Invalid method arguments")
+	}
 
 	for i, v := range splitSigByComma {
 		typed, _ := abi.NewType(v, v, nil)

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -92,6 +92,25 @@ func (a *APIService) ConstructionPreprocess(
 		preprocessOutputOptions.Nonce = bigObj
 	}
 
+	// Override gas_price
+	if v, ok := request.Metadata["gas_price"]; ok {
+		stringObj, ok := v.(string)
+		if !ok {
+			return nil, svcErrors.WrapErr(
+				svcErrors.ErrInvalidGasPrice,
+				fmt.Errorf("%s is not a valid gas_price string", v),
+			)
+		}
+		bigObj, ok := new(big.Int).SetString(stringObj, 10) //nolint:gomnd
+		if !ok {
+			return nil, svcErrors.WrapErr(
+				svcErrors.ErrInvalidGasPrice,
+				fmt.Errorf("%s is not a valid gas_price", v),
+			)
+		}
+		preprocessOutputOptions.GasPrice = bigObj
+	}
+
 	// Only supports ERC20 transfers
 	currency := fromOp.Amount.Currency
 	if _, ok := request.Metadata["method_signature"]; !ok && !isNativeCurrency(currency) {

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -154,7 +154,6 @@ func (a *APIService) ConstructionPreprocess(
 		}
 		preprocessOutputOptions.ContractAddress = checkTo
 		preprocessOutputOptions.Data = data
-		preprocessOutputOptions.Value = big.NewInt(0) // MATIC value is 0 in any contract call
 		preprocessOutputOptions.MethodSignature = methodSigStringObj
 		preprocessOutputOptions.MethodArgs = methodArgs
 
@@ -181,7 +180,6 @@ func matchTransferOperations(operations []*types.Operation, isContractCall bool)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("in 0 value")
 	valueTwo, err := strconv.ParseInt(operations[1].Amount.Value, 10, 64)
 	if err != nil {
 		log.Fatal(err)
@@ -222,8 +220,6 @@ func matchTransferOperations(operations []*types.Operation, isContractCall bool)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		fmt.Println("matches..!!", matches[0])
 
 		fromOp, _ := matches[0].First()
 		toOp, _ := matches[1].First()

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -144,6 +144,11 @@ func (a *APIService) ConstructionPreprocess(
 				fmt.Errorf("%s is not a valid string", contractAddress),
 			)
 		}
+		checkContractAddress, ok := polygon.ChecksumAddress(contractAddress)
+		if !ok {
+			err := errors.New("contract address is not a valid address")
+			return nil, svcErrors.WrapErr(svcErrors.ErrInvalidAddress, err)
+		}
 		var methodArgs []string
 		if v, ok := request.Metadata["method_args"]; ok {
 			methodArgsBytes, _ := json.Marshal(v)
@@ -156,7 +161,7 @@ func (a *APIService) ConstructionPreprocess(
 		if err != nil {
 			return nil, svcErrors.WrapErr(svcErrors.ErrFetchFunctionSignatureMethodID, err)
 		}
-		preprocessOutputOptions.ContractAddress = contractAddress
+		preprocessOutputOptions.ContractAddress = checkContractAddress
 		preprocessOutputOptions.Data = data
 		preprocessOutputOptions.Value = big.NewInt(0) // MATIC value is 0 in any contract call
 		preprocessOutputOptions.MethodSignature = methodSigStringObj

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -137,18 +137,6 @@ func (a *APIService) ConstructionPreprocess(
 				fmt.Errorf("%s is not a valid signature string", v),
 			)
 		}
-		contractAddress, ok := request.Metadata["contract_address"].(string)
-		if !ok {
-			return nil, svcErrors.WrapErr(
-				svcErrors.ErrInvalidAddress,
-				fmt.Errorf("%s is not a valid string", contractAddress),
-			)
-		}
-		checkContractAddress, ok := polygon.ChecksumAddress(contractAddress)
-		if !ok {
-			err := errors.New("contract address is not a valid address")
-			return nil, svcErrors.WrapErr(svcErrors.ErrInvalidAddress, err)
-		}
 		var methodArgs []string
 		if v, ok := request.Metadata["method_args"]; ok {
 			methodArgsBytes, _ := json.Marshal(v)
@@ -161,7 +149,7 @@ func (a *APIService) ConstructionPreprocess(
 		if err != nil {
 			return nil, svcErrors.WrapErr(svcErrors.ErrFetchFunctionSignatureMethodID, err)
 		}
-		preprocessOutputOptions.ContractAddress = checkContractAddress
+		preprocessOutputOptions.ContractAddress = checkTo
 		preprocessOutputOptions.Data = data
 		preprocessOutputOptions.Value = big.NewInt(0) // MATIC value is 0 in any contract call
 		preprocessOutputOptions.MethodSignature = methodSigStringObj

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -275,11 +275,11 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 	if len(splitSigByLeadingParenthesis) < 2 {
 		return data, nil
 	}
-	splitSigByLastParanthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
-	if len(splitSigByLastParanthesis) < 1 {
+	splitSigByTrailingParenthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
+	if len(splitSigByTrailingParenthesis) < 1 {
 		return data, nil
 	}
-	splitSigByComma := strings.Split(splitSigByLastParanthesis[0], ",")
+	splitSigByComma := strings.Split(splitSigByTrailingParenthesis[0], ",")
 	fmt.Println(splitSigByComma)
 
 	for i, v := range splitSigByComma {

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -161,10 +161,13 @@ func (a *APIService) ConstructionPreprocess(
 		preprocessOutputOptions.TokenAddress = contractAddress
 		preprocessOutputOptions.Data = data
 		preprocessOutputOptions.Value = big.NewInt(0) // MATIC value is 0 in any contract call
+		preprocessOutputOptions.MethodSignature = methodSigStringObj
+		preprocessOutputOptions.MethodArgs = methodArgs
 
 	}
 
 	marshaled, err := marshalJSONMap(preprocessOutputOptions)
+	fmt.Println(marshaled)
 	if err != nil {
 		return nil, svcErrors.WrapErr(svcErrors.ErrUnableToParseIntermediateResult, err)
 	}

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -158,7 +158,6 @@ func (a *APIService) ConstructionPreprocess(
 	}
 
 	marshaled, err := marshalJSONMap(preprocessOutputOptions)
-	fmt.Println(marshaled)
 	if err != nil {
 		return nil, svcErrors.WrapErr(svcErrors.ErrUnableToParseIntermediateResult, err)
 	}
@@ -296,7 +295,6 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 		return data, nil
 	}
 	splitSigByComma := strings.Split(splitSigByTrailingParenthesis[0], ",")
-	fmt.Println(splitSigByComma)
 
 	for i, v := range splitSigByComma {
 		typed, _ := abi.NewType(v, v, nil)
@@ -331,7 +329,6 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 			}
 		case strings.HasPrefix(v, "bool"):
 			{
-				fmt.Println("in bool case")
 				value, err := strconv.ParseBool(methodArgs[i])
 				if err != nil {
 					log.Fatal(err)
@@ -344,7 +341,5 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 	}
 	abiEncodeData, _ := arguments.PackValues(argumentsData)
 	data = append(data, abiEncodeData...)
-	fmt.Println("final data:", data)
-
 	return data, nil
 }

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -117,14 +117,13 @@ func TestPreprocess(t *testing.T) {
 				"nonce":            "34",
 				"method_signature": "approve(address,uint256)",
 				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
-				"contract_address": preprocessTokenContractAddress,
 			},
 			expectedResponse: &types.ConstructionPreprocessResponse{
 				Options: map[string]interface{}{
 					"from":             preprocessFromAddress,
 					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
 					"value":            "0x0",
-					"contract_address": preprocessTokenContractAddress,
+					"contract_address": preprocessToAddress,
 					"data":             preprocessGenericData,
 					"nonce":            "0x22",
 					"method_signature": "approve(address,uint256)",

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -37,6 +37,9 @@ var (
 	preprocessGasPrice             = uint64(100000000000)
 	preprocessGasPriceHex          = hexutil.EncodeUint64(preprocessGasPrice)
 	preprocessGenericData          = "0x095ea7b3000000000000000000000000d10a72cf054650931365cc44d912a4fd7525705800000000000000000000000000000000000000000000000000000000000003e8"
+	methodSignature                = "approve(address,uint256)"
+	methodArgs                     = []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"}
+	expectedMethodArgs             = []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"}
 )
 
 func TestPreprocess(t *testing.T) {
@@ -115,8 +118,8 @@ func TestPreprocess(t *testing.T) {
 			operations: templateOperations(preprocessTransferValue, polygon.Currency),
 			metadata: map[string]interface{}{
 				"nonce":            "34",
-				"method_signature": "approve(address,uint256)",
-				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+				"method_signature": methodSignature,
+				"method_args":      methodArgs,
 			},
 			expectedResponse: &types.ConstructionPreprocessResponse{
 				Options: map[string]interface{}{
@@ -126,8 +129,8 @@ func TestPreprocess(t *testing.T) {
 					"contract_address": preprocessToAddress,
 					"data":             preprocessGenericData,
 					"nonce":            "0x22",
-					"method_signature": "approve(address,uint256)",
-					"method_args":      []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+					"method_signature": methodSignature,
+					"method_args":      expectedMethodArgs,
 				},
 			},
 		},
@@ -146,8 +149,8 @@ func TestPreprocess(t *testing.T) {
 					"contract_address": preprocessToAddress,
 					"data":             preprocessGenericData,
 					"nonce":            "0x22",
-					"method_signature": "approve(address,uint256)",
-					"method_args":      []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+					"method_signature": methodSignature,
+					"method_args":      expectedMethodArgs,
 				},
 			},
 		},

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -122,7 +122,7 @@ func TestPreprocess(t *testing.T) {
 				Options: map[string]interface{}{
 					"from":             preprocessFromAddress,
 					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
-					"value":            "0x0",
+					"value":            "0x1",
 					"contract_address": preprocessToAddress,
 					"data":             preprocessGenericData,
 					"nonce":            "0x22",

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -36,6 +36,7 @@ var (
 	preprocessData             = "0xa9059cbb000000000000000000000000efd3dc58d60af3295b92ecd484caeb3a2f30b3e70000000000000000000000000000000000000000000000000000000000000001" // nolint
 	preprocessGasPrice         = uint64(100000000000)
 	preprocessGasPriceHex      = hexutil.EncodeUint64(preprocessGasPrice)
+	preprocessGenericData      = "0x095ea7b3000000000000000000000000d10a72cf054650931365cc44d912a4fd7525705800000000000000000000000000000000000000000000000000000000000003e8"
 )
 
 func TestPreprocess(t *testing.T) {
@@ -107,6 +108,27 @@ func TestPreprocess(t *testing.T) {
 					"token_address": preprocessTokenContractAddress,
 					"data":          preprocessData,
 					"nonce":         "0x22",
+				},
+			},
+		},
+		"happy path: Generic Contract call": {
+			operations: templateOperations(preprocessTransferValue, polygon.Currency),
+			metadata: map[string]interface{}{
+				"nonce":            "34",
+				"method_signature": "approve(address,uint256)",
+				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+				"contract_address": preprocessTokenContractAddress,
+			},
+			expectedResponse: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{
+					"from":             preprocessFromAddress,
+					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
+					"value":            "0x0",
+					"contract_address": preprocessTokenContractAddress,
+					"data":             preprocessGenericData,
+					"nonce":            "0x22",
+					"method_signature": "approve(address,uint256)",
+					"method_args":      []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
 				},
 			},
 		},
@@ -249,6 +271,18 @@ func TestPreprocess(t *testing.T) {
 			expectedResponse: nil,
 			expectedError: templateError(
 				svcErrors.ErrInvalidTokenContractAddress, "token contract address is not a valid address"),
+		},
+		"error: contract address invalid": {
+			operations: templateOperations(preprocessTransferValue, polygon.Currency),
+			metadata: map[string]interface{}{
+				"nonce":            "34",
+				"method_signature": "approve(address,uint256)",
+				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+				"contract_address": "invalid_contract_address",
+			},
+			expectedResponse: nil,
+			expectedError: templateError(
+				svcErrors.ErrInvalidAddress, "contract address is not a valid address"),
 		},
 	}
 

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/maticnetwork/polygon-rosetta/polygon"
 	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
-	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -30,13 +30,13 @@ var (
 	preprocessFromAddress          = fromAddress
 	preprocessToAddress            = toAddress
 	preprocessTokenContractAddress = tokenContractAddress
-
-	preprocessTransferValue    = uint64(1)
-	preprocessTransferValueHex = hexutil.EncodeUint64(preprocessTransferValue)
-	preprocessData             = "0xa9059cbb000000000000000000000000efd3dc58d60af3295b92ecd484caeb3a2f30b3e70000000000000000000000000000000000000000000000000000000000000001" // nolint
-	preprocessGasPrice         = uint64(100000000000)
-	preprocessGasPriceHex      = hexutil.EncodeUint64(preprocessGasPrice)
-	preprocessGenericData      = "0x095ea7b3000000000000000000000000d10a72cf054650931365cc44d912a4fd7525705800000000000000000000000000000000000000000000000000000000000003e8"
+	preprocessZeroTransferValue    = uint64(0)
+	preprocessTransferValue        = uint64(1)
+	preprocessTransferValueHex     = hexutil.EncodeUint64(preprocessTransferValue)
+	preprocessData                 = "0xa9059cbb000000000000000000000000efd3dc58d60af3295b92ecd484caeb3a2f30b3e70000000000000000000000000000000000000000000000000000000000000001" // nolint
+	preprocessGasPrice             = uint64(100000000000)
+	preprocessGasPriceHex          = hexutil.EncodeUint64(preprocessGasPrice)
+	preprocessGenericData          = "0x095ea7b3000000000000000000000000d10a72cf054650931365cc44d912a4fd7525705800000000000000000000000000000000000000000000000000000000000003e8"
 )
 
 func TestPreprocess(t *testing.T) {
@@ -113,6 +113,26 @@ func TestPreprocess(t *testing.T) {
 		},
 		"happy path: Generic Contract call": {
 			operations: templateOperations(preprocessTransferValue, polygon.Currency),
+			metadata: map[string]interface{}{
+				"nonce":            "34",
+				"method_signature": "approve(address,uint256)",
+				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+			},
+			expectedResponse: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{
+					"from":             preprocessFromAddress,
+					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
+					"value":            "0x0",
+					"contract_address": preprocessToAddress,
+					"data":             preprocessGenericData,
+					"nonce":            "0x22",
+					"method_signature": "approve(address,uint256)",
+					"method_args":      []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
+				},
+			},
+		},
+		"happy path: Generic Contract call with zero transfer value": {
+			operations: templateOperations(preprocessZeroTransferValue, polygon.Currency),
 			metadata: map[string]interface{}{
 				"nonce":            "34",
 				"method_signature": "approve(address,uint256)",

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -272,18 +272,6 @@ func TestPreprocess(t *testing.T) {
 			expectedError: templateError(
 				svcErrors.ErrInvalidTokenContractAddress, "token contract address is not a valid address"),
 		},
-		"error: contract address invalid": {
-			operations: templateOperations(preprocessTransferValue, polygon.Currency),
-			metadata: map[string]interface{}{
-				"nonce":            "34",
-				"method_signature": "approve(address,uint256)",
-				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
-				"contract_address": "invalid_contract_address",
-			},
-			expectedResponse: nil,
-			expectedError: templateError(
-				svcErrors.ErrInvalidAddress, "contract address is not a valid address"),
-		},
 	}
 
 	for name, test := range tests {

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -71,23 +71,27 @@ type Client interface {
 //
 // Value here is MATIC. It will always be 0 for ERC20 tokens
 type options struct {
-	From         string   `json:"from"`
-	Nonce        *big.Int `json:"nonce,omitempty"`
-	Data         []byte   `json:"data,omitempty"`
-	To           string   `json:"to"`
-	TokenAddress string   `json:"token_address,omitempty"`
-	Value        *big.Int `json:"value,omitempty"`
-	GasPrice     *big.Int `json:"gas_price,omitempty"`
+	From            string   `json:"from"`
+	Nonce           *big.Int `json:"nonce,omitempty"`
+	Data            []byte   `json:"data,omitempty"`
+	To              string   `json:"to"`
+	TokenAddress    string   `json:"token_address,omitempty"`
+	Value           *big.Int `json:"value,omitempty"`
+	GasPrice        *big.Int `json:"gas_price,omitempty"`
+	MethodSignature string   `json:"method_signature,omitempty"`
+	MethodArgs      []string `json:"method_args,omitempty"`
 }
 
 type optionsWire struct {
-	From         string `json:"from"`
-	Nonce        string `json:"nonce,omitempty"`
-	Data         string `json:"data,omitempty"`
-	To           string `json:"to"`
-	TokenAddress string `json:"token_address,omitempty"`
-	Value        string `json:"value,omitempty"`
-	GasPrice     string `json:"gas_price,omitempty"`
+	From            string   `json:"from"`
+	Nonce           string   `json:"nonce,omitempty"`
+	Data            string   `json:"data,omitempty"`
+	To              string   `json:"to"`
+	TokenAddress    string   `json:"token_address,omitempty"`
+	Value           string   `json:"value,omitempty"`
+	GasPrice        string   `json:"gas_price,omitempty"`
+	MethodSignature string   `json:"method_signature,omitempty"`
+	MethodArgs      []string `json:"method_args,omitempty"`
 }
 
 func (o *options) MarshalJSON() ([]byte, error) {
@@ -116,6 +120,14 @@ func (o *options) MarshalJSON() ([]byte, error) {
 		ow.GasPrice = hexutil.EncodeBig(o.GasPrice)
 	}
 
+	if len(o.MethodSignature) > 0 {
+		ow.MethodSignature = o.MethodSignature
+	}
+
+	if len(o.MethodArgs) > 0 {
+		ow.MethodArgs = o.MethodArgs
+	}
+
 	return json.Marshal(ow)
 }
 
@@ -127,6 +139,14 @@ func (o *options) UnmarshalJSON(data []byte) error {
 	o.From = ow.From
 	o.To = ow.To
 	o.TokenAddress = ow.TokenAddress
+
+	if len(ow.MethodSignature) > 0 {
+		o.MethodSignature = ow.MethodSignature
+	}
+
+	if len(ow.MethodArgs) > 0 {
+		o.MethodArgs = ow.MethodArgs
+	}
 
 	if len(ow.Nonce) > 0 {
 		nonce, err := hexutil.DecodeBig(ow.Nonce)
@@ -164,21 +184,25 @@ func (o *options) UnmarshalJSON(data []byte) error {
 }
 
 type metadata struct {
-	Nonce    uint64   `json:"nonce"`
-	GasPrice *big.Int `json:"gas_price"`
-	GasLimit *big.Int `json:"gas_limit,omitempty"`
-	Data     []byte   `json:"data,omitempty"`
-	To       string   `json:"to,omitempty"`
-	Value    *big.Int `json:"value,omitempty"`
+	Nonce           uint64   `json:"nonce"`
+	GasPrice        *big.Int `json:"gas_price"`
+	GasLimit        *big.Int `json:"gas_limit,omitempty"`
+	Data            []byte   `json:"data,omitempty"`
+	To              string   `json:"to,omitempty"`
+	Value           *big.Int `json:"value,omitempty"`
+	MethodSignature string   `json:"method_signature,omitempty"`
+	MethodArgs      []string `json:"method_args,omitempty"`
 }
 
 type metadataWire struct {
-	Nonce    string `json:"nonce"`
-	GasPrice string `json:"gas_price"`
-	GasLimit string `json:"gas_limit,omitempty"`
-	Data     string `json:"data,omitempty"`
-	To       string `json:"to,omitempty"`
-	Value    string `json:"value,omitempty"`
+	Nonce           string   `json:"nonce"`
+	GasPrice        string   `json:"gas_price"`
+	GasLimit        string   `json:"gas_limit,omitempty"`
+	Data            string   `json:"data,omitempty"`
+	To              string   `json:"to,omitempty"`
+	Value           string   `json:"value,omitempty"`
+	MethodSignature string   `json:"method_signature,omitempty"`
+	MethodArgs      []string `json:"method_args,omitempty"`
 }
 
 func (m *metadata) MarshalJSON() ([]byte, error) {
@@ -198,6 +222,14 @@ func (m *metadata) MarshalJSON() ([]byte, error) {
 
 	if m.Value != nil {
 		mw.Value = hexutil.EncodeBig(m.Value)
+	}
+
+	if len(m.MethodSignature) > 0 {
+		mw.MethodSignature = m.MethodSignature
+	}
+
+	if len(m.MethodArgs) > 0 {
+		mw.MethodArgs = m.MethodArgs
 	}
 
 	return json.Marshal(mw)
@@ -245,6 +277,14 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		m.Value = value
+	}
+
+	if len(mw.MethodSignature) > 0 {
+		m.MethodSignature = mw.MethodSignature
+	}
+
+	if len(mw.MethodArgs) > 0 {
+		m.MethodArgs = mw.MethodArgs
 	}
 
 	return nil

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -76,6 +76,7 @@ type options struct {
 	Data            []byte   `json:"data,omitempty"`
 	To              string   `json:"to"`
 	TokenAddress    string   `json:"token_address,omitempty"`
+	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           *big.Int `json:"value,omitempty"`
 	GasPrice        *big.Int `json:"gas_price,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
@@ -88,6 +89,7 @@ type optionsWire struct {
 	Data            string   `json:"data,omitempty"`
 	To              string   `json:"to"`
 	TokenAddress    string   `json:"token_address,omitempty"`
+	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           string   `json:"value,omitempty"`
 	GasPrice        string   `json:"gas_price,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
@@ -110,6 +112,10 @@ func (o *options) MarshalJSON() ([]byte, error) {
 
 	if len(o.TokenAddress) > 0 {
 		ow.TokenAddress = o.TokenAddress
+	}
+
+	if len(o.ContractAddress) > 0 {
+		ow.ContractAddress = o.ContractAddress
 	}
 
 	if o.Value != nil {
@@ -138,7 +144,14 @@ func (o *options) UnmarshalJSON(data []byte) error {
 	}
 	o.From = ow.From
 	o.To = ow.To
-	o.TokenAddress = ow.TokenAddress
+
+	if len(ow.TokenAddress) > 0 {
+		o.TokenAddress = ow.TokenAddress
+	}
+
+	if len(ow.ContractAddress) > 0 {
+		o.ContractAddress = ow.ContractAddress
+	}
 
 	if len(ow.MethodSignature) > 0 {
 		o.MethodSignature = ow.MethodSignature

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -98,8 +98,12 @@ type optionsWire struct {
 
 func (o *options) MarshalJSON() ([]byte, error) {
 	ow := &optionsWire{
-		From: o.From,
-		To:   o.To,
+		From:            o.From,
+		To:              o.To,
+		ContractAddress: o.ContractAddress,
+		MethodSignature: o.MethodSignature,
+		MethodArgs:      o.MethodArgs,
+		TokenAddress:    o.TokenAddress,
 	}
 
 	if o.Nonce != nil {
@@ -110,28 +114,12 @@ func (o *options) MarshalJSON() ([]byte, error) {
 		ow.Data = hexutil.Encode(o.Data)
 	}
 
-	if len(o.TokenAddress) > 0 {
-		ow.TokenAddress = o.TokenAddress
-	}
-
-	if len(o.ContractAddress) > 0 {
-		ow.ContractAddress = o.ContractAddress
-	}
-
 	if o.Value != nil {
 		ow.Value = hexutil.EncodeBig(o.Value)
 	}
 
 	if o.GasPrice != nil {
 		ow.GasPrice = hexutil.EncodeBig(o.GasPrice)
-	}
-
-	if len(o.MethodSignature) > 0 {
-		ow.MethodSignature = o.MethodSignature
-	}
-
-	if len(o.MethodArgs) > 0 {
-		ow.MethodArgs = o.MethodArgs
 	}
 
 	return json.Marshal(ow)
@@ -144,22 +132,10 @@ func (o *options) UnmarshalJSON(data []byte) error {
 	}
 	o.From = ow.From
 	o.To = ow.To
-
-	if len(ow.TokenAddress) > 0 {
-		o.TokenAddress = ow.TokenAddress
-	}
-
-	if len(ow.ContractAddress) > 0 {
-		o.ContractAddress = ow.ContractAddress
-	}
-
-	if len(ow.MethodSignature) > 0 {
-		o.MethodSignature = ow.MethodSignature
-	}
-
-	if len(ow.MethodArgs) > 0 {
-		o.MethodArgs = ow.MethodArgs
-	}
+	o.TokenAddress = ow.TokenAddress
+	o.ContractAddress = ow.ContractAddress
+	o.MethodSignature = ow.MethodSignature
+	o.MethodArgs = ow.MethodArgs
 
 	if len(ow.Nonce) > 0 {
 		nonce, err := hexutil.DecodeBig(ow.Nonce)
@@ -220,9 +196,11 @@ type metadataWire struct {
 
 func (m *metadata) MarshalJSON() ([]byte, error) {
 	mw := &metadataWire{
-		Nonce:    hexutil.Uint64(m.Nonce).String(),
-		GasPrice: hexutil.EncodeBig(m.GasPrice),
-		To:       m.To,
+		Nonce:           hexutil.Uint64(m.Nonce).String(),
+		GasPrice:        hexutil.EncodeBig(m.GasPrice),
+		To:              m.To,
+		MethodSignature: m.MethodSignature,
+		MethodArgs:      m.MethodArgs,
 	}
 
 	if m.GasLimit != nil {
@@ -235,14 +213,6 @@ func (m *metadata) MarshalJSON() ([]byte, error) {
 
 	if m.Value != nil {
 		mw.Value = hexutil.EncodeBig(m.Value)
-	}
-
-	if len(m.MethodSignature) > 0 {
-		mw.MethodSignature = m.MethodSignature
-	}
-
-	if len(m.MethodArgs) > 0 {
-		mw.MethodArgs = m.MethodArgs
 	}
 
 	return json.Marshal(mw)
@@ -267,6 +237,8 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 	m.GasPrice = gasPrice
 	m.Nonce = nonce
 	m.To = mw.To
+	m.MethodSignature = mw.MethodSignature
+	m.MethodArgs = mw.MethodArgs
 
 	if len(mw.GasLimit) > 0 {
 		gasLimit, err := hexutil.DecodeBig(mw.GasLimit)
@@ -290,14 +262,6 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		m.Value = value
-	}
-
-	if len(mw.MethodSignature) > 0 {
-		m.MethodSignature = mw.MethodSignature
-	}
-
-	if len(mw.MethodArgs) > 0 {
-		m.MethodArgs = mw.MethodArgs
 	}
 
 	return nil

--- a/services/construction/utils.go
+++ b/services/construction/utils.go
@@ -20,10 +20,9 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/maticnetwork/polygon-rosetta/polygon"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
-
+	"github.com/maticnetwork/polygon-rosetta/polygon"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -132,5 +131,31 @@ func rosettaOperations(
 				Currency: currency,
 			},
 		},
+	}
+}
+
+// contractCallMethodID calculates the first 4 bytes of the method
+// signature for function call on contract
+func contractCallMethodID(methodSig string) ([]byte, error) {
+	fnSignature := []byte(methodSig)
+	hash := sha3.NewLegacyKeccak256()
+	if _, err := hash.Write(fnSignature); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil)[:4], nil
+}
+
+func hasTransferData(data []byte) bool {
+	methodID := data[:4]
+	transferFnSignature := []byte("transfer(address,uint256)")
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write(transferFnSignature)
+	transfetMethodID := hash.Sum(nil)[:4]
+	res := bytes.Compare(methodID, transfetMethodID)
+	if res == 0 {
+		return true
+	} else {
+		return false
 	}
 }

--- a/services/construction/utils.go
+++ b/services/construction/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/maticnetwork/polygon-rosetta/polygon"
+
 	"golang.org/x/crypto/sha3"
 )
 

--- a/services/construction/utils.go
+++ b/services/construction/utils.go
@@ -148,11 +148,8 @@ func contractCallMethodID(methodSig string) ([]byte, error) {
 
 func hasTransferData(data []byte) bool {
 	methodID := data[:4]
-	transferFnSignature := []byte("transfer(address,uint256)")
-	hash := sha3.NewLegacyKeccak256()
-	hash.Write(transferFnSignature)
-	transfetMethodID := hash.Sum(nil)[:4]
-	res := bytes.Compare(methodID, transfetMethodID)
+	expectedMethodID, _ := erc20TransferMethodID()
+	res := bytes.Compare(methodID, expectedMethodID)
 	if res == 0 {
 		return true
 	} else {

--- a/services/construction/utils.go
+++ b/services/construction/utils.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"log"
 	"math/big"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -141,7 +142,7 @@ func contractCallMethodID(methodSig string) ([]byte, error) {
 	fnSignature := []byte(methodSig)
 	hash := sha3.NewLegacyKeccak256()
 	if _, err := hash.Write(fnSignature); err != nil {
-		return nil, err
+		log.Fatal(err)
 	}
 
 	return hash.Sum(nil)[:4], nil

--- a/services/construction/utils.go
+++ b/services/construction/utils.go
@@ -151,9 +151,8 @@ func hasTransferData(data []byte) bool {
 	methodID := data[:4]
 	expectedMethodID, _ := erc20TransferMethodID()
 	res := bytes.Compare(methodID, expectedMethodID)
-	if res == 0 {
-		return true
-	} else {
+	if res != 0 {
 		return false
 	}
+	return true
 }


### PR DESCRIPTION
In this PR,

there is the logic added for a generic contract call using rosetta APIs, now users can make any contract call by passing a method signature and method arguments in preprocess endpoint. An ABI encoded data will be created w.r.t method signature and method arguments provided by the user in preprocess request. Now further to broad cast tx process is similar to previous flow.

successful broadcast of generic call using rosetta apis:
https://mumbai.polygonscan.com/tx/0xad851b7ce6e928eb006bff8e77ea33e4489566ff150ac4d87f796a0827f2ee0e