### PR TITLE
Send burnt tx fees to burn contract to finish up EIP-1559 fee handling

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,7 +86,13 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 	var client *polygon.Client
 	if cfg.Mode == configuration.Online {
 		var err error
-		client, err = polygon.NewClient(cfg.BorURL, cfg.Params, cfg.SkipGethAdmin, cfg.GethHeaders)
+		client, err = polygon.NewClient(&polygon.ClientConfig{
+			URL:            cfg.BorURL,
+			ChainConfig:    cfg.Params,
+			SkipAdminCalls: cfg.SkipGethAdmin,
+			Headers:        cfg.GethHeaders,
+			BurntContract:  cfg.BurntContract,
+		})
 		if err != nil {
 			return fmt.Errorf("%w: cannot initialize polygon client", err)
 		}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -109,6 +109,9 @@ type Configuration struct {
 
 	// Block Reward Data
 	Params *params.ChainConfig
+
+	// Governance contract where the token will be sent to and burnt in london fork
+	BurntContract map[string]string
 }
 
 // LoadConfiguration attempts to create a new Configuration
@@ -138,6 +141,9 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = polygon.MainnetGenesisBlockIdentifier
 		config.Params = params.MainnetChainConfig
 		config.Params.ChainID.SetString(MainnetChainID, 10)
+		config.BurntContract = map[string]string{
+			"0": "0x0000000000000000000000000000000000000000",
+		} // TODO add burn contract and block when mainnet forks to support EIP-1559
 	case Testnet, Mumbai:
 		config.Network = &types.NetworkIdentifier{
 			Blockchain: polygon.Blockchain,
@@ -146,6 +152,9 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = polygon.MumbaiGenesisBlockIdentifier
 		config.Params = params.GoerliChainConfig
 		config.Params.ChainID.SetString(MumbaiChainID, 10)
+		config.BurntContract = map[string]string{
+			"22640000": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38",
+		}
 	case "":
 		return nil, errors.New("NETWORK must be populated")
 	default:

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -68,6 +68,9 @@ func TestLoadConfiguration(t *testing.T) {
 				BorURL:                 DefaultBorURL,
 				SkipGethAdmin:          false,
 				GethHeaders:            nil,
+				BurntContract: map[string]string{
+					"0": "0x0000000000000000000000000000000000000000",
+				},
 			},
 		},
 		"all set (mainnet) + geth": {
@@ -93,6 +96,9 @@ func TestLoadConfiguration(t *testing.T) {
 					{Key: "X-Auth-Token", Value: "12345-ABCDE"},
 					{Key: "X-Api-Version", Value: "2"},
 				},
+				BurntContract: map[string]string{
+					"0": "0x0000000000000000000000000000000000000000",
+				},
 			},
 		},
 		"all set (mumbai)": {
@@ -115,6 +121,9 @@ func TestLoadConfiguration(t *testing.T) {
 				GethHeaders: []*polygon.HTTPHeader{
 					{Key: "X-Auth-Token", Value: "12345-ABCDE"},
 					{Key: "X-Api-Version", Value: "2"},
+				},
+				BurntContract: map[string]string{
+					"22640000": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38",
 				},
 			},
 		},

--- a/polygon/mock_client.go
+++ b/polygon/mock_client.go
@@ -96,6 +96,9 @@ func createMockClient(ctx context.Context, t *testing.T) (*mockClient, error) {
 		currencyFetcher: cf,
 		p:               params.RopstenChainConfig,
 		traceSemaphore:  semaphore.NewWeighted(100), //nolint
+		burntContract: map[string]string{
+			"22640000": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38",
+		},
 	}
 
 	return &mockClient{

--- a/polygon/testdata/block/block_response_22743478.json
+++ b/polygon/testdata/block/block_response_22743478.json
@@ -77,6 +77,31 @@
                 "decimals": 18
               }
             }
+          },
+          {
+            "operation_identifier": {
+              "index": 2
+            },
+            "related_operations": [
+              {
+                "index": 0
+              },
+              {
+                "index": 1
+              }
+            ],
+            "type": "FEE",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38"
+            },
+            "amount": {
+              "value": "7",
+              "currency": {
+                "symbol": "MATIC",
+                "decimals": 18
+              }
+            }
           }
         ],
         "metadata": {
@@ -172,6 +197,31 @@
             "operation_identifier": {
               "index": 2
             },
+            "related_operations": [
+              {
+                "index": 0
+              },
+              {
+                "index": 1
+              }
+            ],
+            "type": "FEE",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38"
+            },
+            "amount": {
+              "value": "7",
+              "currency": {
+                "symbol": "MATIC",
+                "decimals": 18
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 3
+            },
             "type": "",
             "status": "SUCCESS",
             "account": {
@@ -180,11 +230,11 @@
           },
           {
             "operation_identifier": {
-              "index": 3
+              "index": 4
             },
             "related_operations": [
               {
-                "index": 2
+                "index": 3
               }
             ],
             "type": "",
@@ -263,6 +313,31 @@
             "operation_identifier": {
               "index": 2
             },
+            "related_operations": [
+              {
+                "index": 0
+              },
+              {
+                "index": 1
+              }
+            ],
+            "type": "FEE",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38"
+            },
+            "amount": {
+              "value": "7",
+              "currency": {
+                "symbol": "MATIC",
+                "decimals": 18
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 3
+            },
             "type": "",
             "status": "SUCCESS",
             "account": {
@@ -271,11 +346,11 @@
           },
           {
             "operation_identifier": {
-              "index": 3
+              "index": 4
             },
             "related_operations": [
               {
-                "index": 2
+                "index": 3
               }
             ],
             "type": "",
@@ -371,6 +446,31 @@
             "operation_identifier": {
               "index": 2
             },
+            "related_operations": [
+              {
+                "index": 0
+              },
+              {
+                "index": 1
+              }
+            ],
+            "type": "FEE",
+            "status": "SUCCESS",
+            "account": {
+              "address": "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38"
+            },
+            "amount": {
+              "value": "7",
+              "currency": {
+                "symbol": "MATIC",
+                "decimals": 18
+              }
+            }
+          },
+          {
+            "operation_identifier": {
+              "index": 3
+            },
             "type": "",
             "status": "SUCCESS",
             "account": {
@@ -379,11 +479,11 @@
           },
           {
             "operation_identifier": {
-              "index": 3
+              "index": 4
             },
             "related_operations": [
               {
-                "index": 2
+                "index": 3
               }
             ],
             "type": "",


### PR DESCRIPTION
This PR implements the accounting for Polygon fee burning as described in https://forum.polygon.technology/t/eip1559-implementation-on-mumbai-testnet/399.  Base fees are to be sent to the appropriate burn contract address which this PR allows to be specified in the client config.
