### PR TITLE
fix state sync tx bugs

### DIFF
--- a/polygon/testdata/block/block_response_135808.json
+++ b/polygon/testdata/block/block_response_135808.json
@@ -12,51 +12,12 @@
         "transactions": [
             {
                 "transaction_identifier": {
-                    "hash": "0xe79e4719c6770b41405f691c18be3346b691e220d730d6b61abb5dd3ac9d71f0"
+                    "hash": "0xf658e64d2c7dd6a2e32d48c582bbf9db0c45c95db72b4ddd23fe73764849dbdc"
                 },
                 "operations": [
                     {
                         "operation_identifier": {
                             "index": 0
-                        },
-                        "type": "FEE",
-                        "status": "SUCCESS",
-                        "account": {
-                            "address": "0x0000000000000000000000000000000000000000"
-                        },
-                        "amount": {
-                            "value": "0",
-                            "currency": {
-                                "symbol": "MATIC",
-                                "decimals": 18
-                            }
-                        }
-                    },
-                    {
-                        "operation_identifier": {
-                            "index": 1
-                        },
-                        "related_operations": [
-                            {
-                                "index": 0
-                            }
-                        ],
-                        "type": "FEE",
-                        "status": "SUCCESS",
-                        "account": {
-                            "address": "0xC26880A0AF2EA0c7E8130e6EC47Af756465452E8"
-                        },
-                        "amount": {
-                            "value": "0",
-                            "currency": {
-                                "symbol": "MATIC",
-                                "decimals": 18
-                            }
-                        }
-                    },
-                    {
-                        "operation_identifier": {
-                            "index": 2
                         },
                         "type": "PAYMENT",
                         "status": "SUCCESS",
@@ -76,11 +37,11 @@
                     },
                     {
                         "operation_identifier": {
-                            "index": 3
+                            "index": 1
                         },
                         "related_operations": [
                             {
-                                "index": 2
+                                "index": 0
                             }
                         ],
                         "type": "PAYMENT",

--- a/polygon/testdata/block/block_response_147648.json
+++ b/polygon/testdata/block/block_response_147648.json
@@ -12,51 +12,12 @@
         "transactions": [
             {
                 "transaction_identifier": {
-                    "hash": "0xe79e4719c6770b41405f691c18be3346b691e220d730d6b61abb5dd3ac9d71f0"
+                    "hash": "0x3f4a5a9cbd755b65c85954650abc7c2c39331311bf8490b8ed42c1e0349f65a3"
                 },
                 "operations": [
                     {
                         "operation_identifier": {
                             "index": 0
-                        },
-                        "type": "FEE",
-                        "status": "SUCCESS",
-                        "account": {
-                            "address": "0x0000000000000000000000000000000000000000"
-                        },
-                        "amount": {
-                            "value": "0",
-                            "currency": {
-                                "symbol": "MATIC",
-                                "decimals": 18
-                            }
-                        }
-                    },
-                    {
-                        "operation_identifier": {
-                            "index": 1
-                        },
-                        "related_operations": [
-                            {
-                                "index": 0
-                            }
-                        ],
-                        "type": "FEE",
-                        "status": "SUCCESS",
-                        "account": {
-                            "address": "0xC26880A0AF2EA0c7E8130e6EC47Af756465452E8"
-                        },
-                        "amount": {
-                            "value": "0",
-                            "currency": {
-                                "symbol": "MATIC",
-                                "decimals": 18
-                            }
-                        }
-                    },
-                    {
-                        "operation_identifier": {
-                            "index": 2
                         },
                         "type": "CALL",
                         "status": "SUCCESS",
@@ -73,11 +34,11 @@
                     },
                     {
                         "operation_identifier": {
-                            "index": 3
+                            "index": 1
                         },
                         "related_operations": [
                             {
-                                "index": 2
+                                "index": 0
                             }
                         ],
                         "type": "CALL",

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/maticnetwork/polygon-rosetta/polygon"
 	svcErrors "github.com/maticnetwork/polygon-rosetta/services/errors"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This PR fixes two issues with processing state sync transactions:

1) various 0 value fee ops were being generated when no fees are associated with state sync

2) the tx identifier hash was wrong since state-sync txs have special indicators independent of the hash computed over the tx body. 

Testing: Confirmed the tx identifier hash for the state sync test cases now match those provided by block explorers, and that there are no longer any 0 value fee ops associated with them.