### PR TITLE
override gas limit

### DIFF
--- a/services/construction/construction_service_test.go
+++ b/services/construction/construction_service_test.go
@@ -133,7 +133,7 @@ func TestConstructionFlowWithPendingNonce(t *testing.T) {
 
 	// Test Metadata
 	metadata := &metadata{
-		GasLimit: big.NewInt(21000),
+		GasLimit: 21000,
 		GasPrice: big.NewInt(1000000000),
 		Nonce:    0,
 		To:       "0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d",
@@ -202,7 +202,7 @@ func TestConstructionFlowWithPendingNonce(t *testing.T) {
 	parseMetadata := &parseMetadata{
 		Nonce:    metadata.Nonce,
 		GasPrice: metadata.GasPrice,
-		GasLimit: metadata.GasLimit.Uint64(),
+		GasLimit: metadata.GasLimit,
 		ChainID:  big.NewInt(80001),
 	}
 	assert.Equal(t, &types.ConstructionParseResponse{
@@ -332,7 +332,7 @@ func TestConstructionFlowWithInputNonce(t *testing.T) {
 
 	// Test Metadata
 	metadata := &metadata{
-		GasLimit: big.NewInt(21000),
+		GasLimit: 21000,
 		GasPrice: big.NewInt(1000000000),
 		Nonce:    1,
 		To:       "0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d",
@@ -393,7 +393,7 @@ func TestConstructionFlowWithInputNonce(t *testing.T) {
 	parseMetadata := &parseMetadata{
 		Nonce:    metadata.Nonce,
 		GasPrice: metadata.GasPrice,
-		GasLimit: metadata.GasLimit.Uint64(),
+		GasLimit: metadata.GasLimit,
 		ChainID:  big.NewInt(80001),
 	}
 	assert.Equal(t, &types.ConstructionParseResponse{

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -60,7 +60,7 @@ func (a *APIService) ConstructionPayloads(
 	nonce := metadata.Nonce
 	gasPrice := metadata.GasPrice
 	chainID := a.config.Params.ChainID
-	transferGasLimit := metadata.GasLimit.Uint64()
+	transferGasLimit := metadata.GasLimit
 	transferData := metadata.Data
 
 	// Ensure valid from address

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -113,6 +113,25 @@ func (a *APIService) ConstructionPreprocess(
 		}
 		preprocessOutputOptions.GasPrice = bigObj
 	}
+	
+	// Override gas_limit
+	if v, ok := request.Metadata["gas_limit"]; ok {
+		stringObj, ok := v.(string)
+		if !ok {
+			return nil, svcErrors.WrapErr(
+				svcErrors.ErrInvalidGasLimit,
+				fmt.Errorf("%s is not a valid gas_limit string", v),
+			)
+		}
+		bigObj, ok := new(big.Int).SetString(stringObj, 10) //nolint:gomnd
+		if !ok {
+			return nil, svcErrors.WrapErr(
+				svcErrors.ErrInvalidGasLimit,
+				fmt.Errorf("%s is not a valid gas_limit", v),
+			)
+		}
+		preprocessOutputOptions.GasLimit = bigObj
+	}
 
 	// Only supports ERC20 transfers
 	currency := fromOp.Amount.Currency

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -113,7 +113,7 @@ func (a *APIService) ConstructionPreprocess(
 		}
 		preprocessOutputOptions.GasPrice = bigObj
 	}
-	
+
 	// Override gas_limit
 	if v, ok := request.Metadata["gas_limit"]; ok {
 		stringObj, ok := v.(string)

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -79,6 +79,7 @@ type options struct {
 	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           *big.Int `json:"value,omitempty"`
 	GasPrice        *big.Int `json:"gas_price,omitempty"`
+	GasLimit		*big.Int `json:"gas_limit,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
 	MethodArgs      []string `json:"method_args,omitempty"`
 }
@@ -92,6 +93,7 @@ type optionsWire struct {
 	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           string   `json:"value,omitempty"`
 	GasPrice        string   `json:"gas_price,omitempty"`
+	GasLimit		string	  `json:"gas_limit,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
 	MethodArgs      []string `json:"method_args,omitempty"`
 }
@@ -120,6 +122,10 @@ func (o *options) MarshalJSON() ([]byte, error) {
 
 	if o.GasPrice != nil {
 		ow.GasPrice = hexutil.EncodeBig(o.GasPrice)
+	}
+
+	if o.GasLimit != nil {
+		ow.GasLimit = hexutil.EncodeBig(o.GasLimit)
 	}
 
 	return json.Marshal(ow)
@@ -169,13 +175,21 @@ func (o *options) UnmarshalJSON(data []byte) error {
 		o.GasPrice = gasPrice
 	}
 
+	if len(ow.GasLimit) > 0 {
+		gasLimit, err := hexutil.DecodeBig(ow.GasLimit)
+		if err != nil {
+			return err
+		}
+		o.GasLimit = gasLimit
+	}
+
 	return nil
 }
 
 type metadata struct {
 	Nonce           uint64   `json:"nonce"`
 	GasPrice        *big.Int `json:"gas_price"`
-	GasLimit        *big.Int `json:"gas_limit,omitempty"`
+	GasLimit        uint64   `json:"gas_limit,omitempty"`
 	Data            []byte   `json:"data,omitempty"`
 	To              string   `json:"to,omitempty"`
 	Value           *big.Int `json:"value,omitempty"`
@@ -203,8 +217,8 @@ func (m *metadata) MarshalJSON() ([]byte, error) {
 		MethodArgs:      m.MethodArgs,
 	}
 
-	if m.GasLimit != nil {
-		mw.GasLimit = hexutil.EncodeBig(m.GasLimit)
+	if m.GasLimit > 0 {
+		mw.GasLimit = hexutil.Uint64(m.GasLimit).String()
 	}
 
 	if len(m.Data) > 0 {
@@ -241,7 +255,7 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 	m.MethodArgs = mw.MethodArgs
 
 	if len(mw.GasLimit) > 0 {
-		gasLimit, err := hexutil.DecodeBig(mw.GasLimit)
+		gasLimit, err := hexutil.DecodeUint64(mw.GasLimit)
 		if err != nil {
 			return err
 		}
@@ -270,7 +284,7 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 type parseMetadata struct {
 	Nonce    uint64   `json:"nonce"`
 	GasPrice *big.Int `json:"gas_price"`
-	GasLimit uint64   `json:"gas_limit"`
+	GasLimit uint64	  `json:"gas_limit"`
 	ChainID  *big.Int `json:"chain_id"`
 }
 
@@ -373,6 +387,5 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 	t.GasPrice = gasPrice
 	t.GasLimit = gasLimit
 	t.ChainID = chainID
-	t.GasPrice = gasPrice
 	return nil
 }

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -64,8 +64,8 @@ type Client interface {
 	) (*types.CallResponse, error)
 }
 
-// Nonce is a *big.Int so that its value can be checked against nil
-// in MarshalJSON and ConstructionMetadata. If uint64 is used instead,
+// Nonce and GasLimit are a *big.Int so that their values can be checked against nil
+// in MarshalJSON and ConstructionMetadata. For nonce, if uint64 is used instead,
 // its nil value will be 0 which is a valid nonce. This will cause
 // ConstructionMetadata to make an extra call to eth_getTransactionCount
 //
@@ -79,7 +79,7 @@ type options struct {
 	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           *big.Int `json:"value,omitempty"`
 	GasPrice        *big.Int `json:"gas_price,omitempty"`
-	GasLimit		*big.Int `json:"gas_limit,omitempty"`
+	GasLimit        *big.Int `json:"gas_limit,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
 	MethodArgs      []string `json:"method_args,omitempty"`
 }
@@ -93,7 +93,7 @@ type optionsWire struct {
 	ContractAddress string   `json:"contract_address,omitempty"`
 	Value           string   `json:"value,omitempty"`
 	GasPrice        string   `json:"gas_price,omitempty"`
-	GasLimit		string	  `json:"gas_limit,omitempty"`
+	GasLimit        string   `json:"gas_limit,omitempty"`
 	MethodSignature string   `json:"method_signature,omitempty"`
 	MethodArgs      []string `json:"method_args,omitempty"`
 }
@@ -284,7 +284,7 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 type parseMetadata struct {
 	Nonce    uint64   `json:"nonce"`
 	GasPrice *big.Int `json:"gas_price"`
-	GasLimit uint64	  `json:"gas_limit"`
+	GasLimit uint64   `json:"gas_limit"`
 	ChainID  *big.Int `json:"chain_id"`
 }
 

--- a/services/errors/errors.go
+++ b/services/errors/errors.go
@@ -202,6 +202,13 @@ var (
 		Code:    21, //nolint
 		Message: "Gas price invalid",
 	}
+
+	// ErrInvalidGasLimit is returned when input gas limit
+	// is invalid.
+	ErrInvalidGasLimit = &types.Error{
+		Code:    22, //nolint
+		Message: "Gas limit invalid",
+	}
 )
 
 // WrapErr adds details to the types.Error provided. We use a function


### PR DESCRIPTION
Add support for overriding gas limit. It is of type `uint64`, as this is what geth's core spec enforces as well (see https://github.com/maticnetwork/polygon-rosetta/pull/29#discussion_r872426117)

Flow - before:
- `gas_limit` is estimated in the `/construction/metadata/` step https://github.com/maticnetwork/polygon-rosetta/blob/1e0d9135011c9de0e08d634472a459ba154e6fab/services/construction/metadata.go#L70-L108

Flow - after:
- `gas_limit` is passed in as `uint64` during `/construction/preprocess/` step, and gets passed back to the client as a hex string
- client passes in `gas_limit` as hex string into the `/construction/metadata/` step, and this ends up getting used in the actual construction of the tx payload