### PR TITLE
override gas limit by default

### DIFF
--- a/services/construction/metadata.go
+++ b/services/construction/metadata.go
@@ -67,8 +67,14 @@ func (a *APIService) ConstructionMetadata(
 		return nil, svcErrors.WrapErr(svcErrors.ErrGeth, err)
 	}
 
-	// by default, initialize gasLimit to the TransferGasLimit
-	gasLimit := polygon.TransferGasLimit
+	var gasLimit uint64
+	if input.GasLimit == nil {
+		// by default, initialize gasLimit to the TransferGasLimit
+		gasLimit = polygon.TransferGasLimit
+	} else {
+		gasLimit = input.GasLimit.Uint64()
+	}
+	
 	to := checkTo
 	// Only work for ERC20 transfer
 	if len(input.TokenAddress) > 0 {


### PR DESCRIPTION
There appear to be native MATIC transfer transactions that could exceed the expected 21000 gas limit https://polygonscan.com/tx/0x70ea2f1959edb99d73906ff7439f72c2843af5eca07698c629ea0363f6c970c2

By default, we should override the gas limit if an argument is passed in (which will be the case for CB), and otherwise set it to the typical native transfer gas limit.