### PR TITLE
Fully support arbitrary smart contract calls

### DIFF
--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -45,6 +45,9 @@ var (
 	methodSignature                   = "approve(address,uint256)"
 	methodArgs                        = []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"}
 	expectedMethodArgs                = []interface{}{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"}
+	complexMethodSignature            = "mintItemBatch(address[],string)"
+	complexMethodArgs                 = "000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000b406c0106ba32281ddfa75626479304feb70d0580000000000000000000000003cdc2ce790d740fd8b8e99baf738497c5e2de62000000000000000000000000006da92f4f1815e83cf5a020f952f0e3275a5b156000000000000000000000000f344767634735d588357ed5828488094bef02efe000000000000000000000000000000000000000000000000000000000000002e516d614b57483933397346454464576333347252395453433868647758624357574575454a6b6476714e334a7573000000000000000000000000000000000000"
+	complexMethodData                 = "0x079c66c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000b406c0106ba32281ddfa75626479304feb70d0580000000000000000000000003cdc2ce790d740fd8b8e99baf738497c5e2de62000000000000000000000000006da92f4f1815e83cf5a020f952f0e3275a5b156000000000000000000000000f344767634735d588357ed5828488094bef02efe000000000000000000000000000000000000000000000000000000000000002e516d614b57483933397346454464576333347252395453433868647758624357574575454a6b6476714e334a7573000000000000000000000000000000000000"
 )
 
 func TestPreprocess(t *testing.T) {
@@ -166,6 +169,26 @@ func TestPreprocess(t *testing.T) {
 					"nonce":            "0x22",
 					"method_signature": methodSignature,
 					"method_args":      expectedMethodArgs,
+				},
+			},
+		},
+		"happy path: generic contract call with pre-encoded arguments": {
+			operations: templateOperations(preprocessTransferValue, polygon.Currency),
+			metadata: map[string]interface{}{
+				"nonce":            "34",
+				"method_signature": complexMethodSignature,
+				"method_args":      complexMethodArgs,
+			},
+			expectedResponse: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{
+					"from":             preprocessFromAddress,
+					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
+					"value":            "0x1",
+					"contract_address": preprocessToAddress,
+					"data":             complexMethodData,
+					"nonce":            "0x22",
+					"method_signature": complexMethodSignature,
+					"method_args":      complexMethodArgs,
 				},
 			},
 		},

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -182,7 +182,7 @@ func TestPreprocess(t *testing.T) {
 			expectedResponse: &types.ConstructionPreprocessResponse{
 				Options: map[string]interface{}{
 					"from":             preprocessFromAddress,
-					"to":               preprocessToAddress, // it will be contract address user need to pass in operation
+					"to":               preprocessToAddress,
 					"value":            "0x1",
 					"contract_address": preprocessToAddress,
 					"data":             complexMethodData,

--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -73,33 +73,33 @@ type Client interface {
 //
 // Value here is MATIC. It will always be 0 for ERC20 tokens
 type options struct {
-	From            string   `json:"from"`
-	Nonce           *big.Int `json:"nonce,omitempty"`
-	Data            []byte   `json:"data,omitempty"`
-	To              string   `json:"to"`
-	TokenAddress    string   `json:"token_address,omitempty"`
-	ContractAddress string   `json:"contract_address,omitempty"`
-	Value           *big.Int `json:"value,omitempty"`
-	GasLimit        *big.Int `json:"gas_limit,omitempty"`
-	GasCap          *big.Int `json:"gas_cap,omitempty"`
-	GasTip          *big.Int `json:"gas_tip,omitempty"`
-	MethodSignature string   `json:"method_signature,omitempty"`
-	MethodArgs      []string `json:"method_args,omitempty"`
+	From            string      `json:"from"`
+	Nonce           *big.Int    `json:"nonce,omitempty"`
+	Data            []byte      `json:"data,omitempty"`
+	To              string      `json:"to"`
+	TokenAddress    string      `json:"token_address,omitempty"`
+	ContractAddress string      `json:"contract_address,omitempty"`
+	Value           *big.Int    `json:"value,omitempty"`
+	GasLimit        *big.Int    `json:"gas_limit,omitempty"`
+	GasCap          *big.Int    `json:"gas_cap,omitempty"`
+	GasTip          *big.Int    `json:"gas_tip,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 type optionsWire struct {
-	From            string   `json:"from"`
-	Nonce           string   `json:"nonce,omitempty"`
-	Data            string   `json:"data,omitempty"`
-	To              string   `json:"to"`
-	TokenAddress    string   `json:"token_address,omitempty"`
-	ContractAddress string   `json:"contract_address,omitempty"`
-	Value           string   `json:"value,omitempty"`
-	GasLimit        string   `json:"gas_limit,omitempty"`
-	GasCap          string   `json:"gas_cap,omitempty"`
-	GasTip          string   `json:"gas_tip,omitempty"`
-	MethodSignature string   `json:"method_signature,omitempty"`
-	MethodArgs      []string `json:"method_args,omitempty"`
+	From            string      `json:"from"`
+	Nonce           string      `json:"nonce,omitempty"`
+	Data            string      `json:"data,omitempty"`
+	To              string      `json:"to"`
+	TokenAddress    string      `json:"token_address,omitempty"`
+	ContractAddress string      `json:"contract_address,omitempty"`
+	Value           string      `json:"value,omitempty"`
+	GasLimit        string      `json:"gas_limit,omitempty"`
+	GasCap          string      `json:"gas_cap,omitempty"`
+	GasTip          string      `json:"gas_tip,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 func (o *options) MarshalJSON() ([]byte, error) {
@@ -203,27 +203,27 @@ func (o *options) UnmarshalJSON(data []byte) error {
 }
 
 type metadata struct {
-	Nonce           uint64   `json:"nonce"`
-	GasCap          *big.Int `json:"gas_cap"`
-	GasTip          *big.Int `json:"gas_tip"`
-	GasLimit        uint64   `json:"gas_limit,omitempty"`
-	Data            []byte   `json:"data,omitempty"`
-	To              string   `json:"to,omitempty"`
-	Value           *big.Int `json:"value,omitempty"`
-	MethodSignature string   `json:"method_signature,omitempty"`
-	MethodArgs      []string `json:"method_args,omitempty"`
+	Nonce           uint64      `json:"nonce"`
+	GasCap          *big.Int    `json:"gas_cap"`
+	GasTip          *big.Int    `json:"gas_tip"`
+	GasLimit        uint64      `json:"gas_limit,omitempty"`
+	Data            []byte      `json:"data,omitempty"`
+	To              string      `json:"to,omitempty"`
+	Value           *big.Int    `json:"value,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 type metadataWire struct {
-	Nonce           string   `json:"nonce"`
-	GasCap          string   `json:"gas_cap"`
-	GasTip          string   `json:"gas_tip"`
-	GasLimit        string   `json:"gas_limit,omitempty"`
-	Data            string   `json:"data,omitempty"`
-	To              string   `json:"to,omitempty"`
-	Value           string   `json:"value,omitempty"`
-	MethodSignature string   `json:"method_signature,omitempty"`
-	MethodArgs      []string `json:"method_args,omitempty"`
+	Nonce           string      `json:"nonce"`
+	GasCap          string      `json:"gas_cap"`
+	GasTip          string      `json:"gas_tip"`
+	GasLimit        string      `json:"gas_limit,omitempty"`
+	Data            string      `json:"data,omitempty"`
+	To              string      `json:"to,omitempty"`
+	Value           string      `json:"value,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 func (m *metadata) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
A limitation with all current EVM Rosetta implementations was recently discovered where arbitrary contract calls are not fully supported. These implementations only support simple, single-dimensional types for arguments to contract method calls. This PR closes the gap to enable fully-arbitrary smart contract calls regardless of ABI types used.

## Technical Details

The contract call data has the following shape:

```js
{
	“method_args”: [string, …]  // array-of-strings encoded arguments
	“method_signature”: string, // method ABI e.g. approve(address,uint256)
	“data”: string              // post-encoded contract call data
}
```

This data is passed around in various containers through the construction endpoints–either as “options” or “metadata”, sometimes with the data in-tact and sometimes without. The key point is that **these 3 parameters MUST be consistent** in order for the Payloads endpoint to be able to complete validation. This means that the **method_signature** and **method_args** MUST compile to **data** according to the internal encoding logic.

The proposal is to update the internal encoding logic to support arbitrarily-complex **method_args**. There is a method called [constructContractCallData](https://github.com/coinbase/rosetta-geth-sdk/blob/master/services/construction/preprocess.go#L187), which takes the **method_signature** + **method_args** and returns the serialized **data**. This method implementation is extended to support pre-encoded **method_args** such that it does not have to support all possible data types via the limited array-of-strings interchange format.

## Justification For Approach

It would be impossible to support all possible contract call ABIs with per-argument encoding due to the expressive nature of the ABI type system. Types can have embedded types, which can have dynamic lengths, which can themselves be embedded inside dynamic types, and so on. Because of this expressiveness, and the intricacies of properly encoding data with it, it’s not possible to have a completely independent ABI encoder within the Rosetta implementation, without significant investment. A simpler approach is suggested which allows the client to provide pre-encoded argument data.

## Implications

* In the case of the list-of-strings, **this will provide backwards-compatibility** with current uses of this API. The existing behavior will be maintained. Backwards compatibility is validated by the test suite.
* In the case of a hex-encoded string, no ABI-encoding will be attempted on the Rosetta implementation, and instead it will simply append the argument data to the selector data which will become the full contract call data.

This polymorphic use of method_args is possible because the container where this parameter is held is an [untyped map](https://github.com/coinbase/rosetta-sdk-go/blob/master/types/construction_preprocess_request.go#L35). Logic will be added wherever this parameter is read to accommodate the new dynamism.