### PR TITLE
fix: construction of contract call byte array args

### DIFF
--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -511,6 +511,6 @@ func encodeMethodArgsStrings(sigData []byte, methodSig string, methodArgs []stri
 		}
 		argumentsData = append(argumentsData, argData)
 	}
-	encData, _ := arguments.PackValues(argumentsData)
-	return append(sigData, encData...), nil
+	encData, packErr := arguments.PackValues(argumentsData)
+	return append(sigData, encData...), packErr
 }


### PR DESCRIPTION
### Summary
This PR adds support for parsing fixed-size `byte` array arguments (e.g. `bytes32`) for contract calls.
This PR also modifies the parsing logic to expect a `0x`-prefixed hexadecimal representation of a byte array to be provided for all `bytes` arguments.

### Changes
**Prior Behavior**
All args with types prefixed with "bytes" were copied into byte arrays of size 32.
For types like `bytes4`, geth would throw an error [here](https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/error_handling.go#L79).

Hexadecimal strings like "0xabcdef" were directly copied, leading to slices like `[]byte(["0", "x", "a", "b", ...])`.

**New Behavior**
`encodeMethodArgsStrings ` distinguishes between dynamically-sized byte array arguments and fixed-size byte array arguments.

`bytes` are still converted to byte slices, as is [expected by geth](https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/type.go#L250-L251).

Fixed-size arrays like `bytes32` are converted into golang byte arrays of the corresponding size, [as required by geth](https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/type.go#L248-L249).

Hexadecimal strings like "0xabcdef" are trimmed and hex-decoded, resulting in `[0xab, 0xcd, 0xef]`.

If decoding fails, an error is returned.
If an invalid size (`bytes45`) is passed, an error is returned.
If the decoded byte array length doesn't match the expected size for fixed-size arrays, an error is returned.

See https://github.com/Inphi/optimism-rosetta/pull/103 for corresponding change for optimism's rosetta implementation.
