### PR TITLE
[fix] Use MarshalBinary instead of EncodeToBytes when Submitting Transaction 

### DIFF
--- a/polygon/client.go
+++ b/polygon/client.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	BorTypes "github.com/maticnetwork/polygon-rosetta/polygon/types"
 	"golang.org/x/sync/semaphore"
@@ -248,14 +247,13 @@ func (ec *Client) peers(ctx context.Context) ([]*RosettaTypes.Peer, error) {
 // If the transaction was a contract creation use the TransactionReceipt method to get the
 // contract address after the transaction has been mined.
 func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	data, err := rlp.EncodeToBytes(tx)
-	
+	data, err := tx.MarshalBinary()
 	if err != nil {
 		return err
 	}
 	// We have to remove the first two bytes otherwise DynamicFeeTxs will not send:
 	// https://ethereum.stackexchange.com/questions/124447/eth-sendrawtransaction-with-dynamicfeetx-returns-expected-input-list-for-types
-	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data[2:]))
+	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
 func toBlockNumArg(number *big.Int) string {

--- a/polygon/client.go
+++ b/polygon/client.go
@@ -249,6 +249,7 @@ func (ec *Client) peers(ctx context.Context) ([]*RosettaTypes.Peer, error) {
 // contract address after the transaction has been mined.
 func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	data, err := rlp.EncodeToBytes(tx)
+	
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As indicated by this [thread](https://ethereum.stackexchange.com/questions/124447/eth-sendrawtransaction-with-dynamicfeetx-returns-expected-input-list-for-types) and this [thread](https://github.com/ethereum/go-ethereum/issues/25027) on ethereum stack exchange, we should call MarshallBinary to encode the data for a raw EIP-1559 transaction. 

Calling RLP will generate invalid tx data, which will cause this error when trying to broadcast a transaction to Polygon.  
```
expected input list for types.LegacyTx
```