### PR TITLE
Fetch block index separately from its hash

### DIFF
--- a/polygon/client.go
+++ b/polygon/client.go
@@ -645,7 +645,6 @@ func buildGraphqlCallQuery(blockQuery string, contractAddress string, encodedDat
 	return fmt.Sprintf(`{
 					block(%s){
 						hash
-						number
 						call(data:{
 							to:"%s"
 							data:"%s"
@@ -1283,7 +1282,6 @@ func buildGraphqlBalanceQuery(blockQuery string, address string) string {
 	return fmt.Sprintf(`{
 			block(%s){
 				hash
-				number
 				account(address:"%s"){
 					balance
 					transactionCount
@@ -1415,11 +1413,15 @@ func (ec *Client) Balance(
 		balances = append(balances, nativeBalance)
 	}
 
+	blk, err := ec.getParsedBlock(ctx, "eth_getBlockByHash", bal.Data.Block.Hash, true)
+	if err != nil {
+		return nil, err
+	}
 	return &RosettaTypes.AccountBalanceResponse{
 		Balances: balances,
 		BlockIdentifier: &RosettaTypes.BlockIdentifier{
 			Hash:  bal.Data.Block.Hash,
-			Index: bal.Data.Block.Number,
+			Index: blk.BlockIdentifier.Index,
 		},
 		Metadata: map[string]interface{}{
 			"nonce": nonce.Int64(),
@@ -1436,12 +1438,12 @@ type graphqlCallResponse struct {
 	} `json:"errors"`
 	Data struct {
 		Block struct {
-			Hash   string `json:"hash"`
-			Number int64  `json:"number"`
-			Call   struct {
+			Hash string `json:"hash"`
+			//Number int64  `json:"number"`
+			Call struct {
 				Data    string `json:"data"`
-				Status  int64  `json:"status"`
-				GasUsed int64  `json:"gasUsed"`
+				Status  string `json:"status"`
+				GasUsed string `json:"gasUsed"`
 			} `json:"call"`
 		} `json:"block"`
 	} `json:"data"`

--- a/polygon/currency_fetcher.go
+++ b/polygon/currency_fetcher.go
@@ -113,7 +113,7 @@ func (ecf ERC20CurrencyFetcher) fetchCurrency(
 		return nil, errors.New(RosettaTypes.PrintStruct(decimals.Errors))
 	}
 	// Use default decimals when graphQL call fails
-	if decimals.Data.Block.Call.Status != 1 {
+	if decimals.Data.Block.Call.Status != "0x1" {
 		currency := &RosettaTypes.Currency{
 			Symbol:   defaultERC20Symbol,
 			Decimals: defaultERC20Decimals,
@@ -168,7 +168,7 @@ func (ecf ERC20CurrencyFetcher) fetchCurrency(
 		return nil, errors.New(RosettaTypes.PrintStruct(symbol.Errors))
 	}
 	// Use default symbol when graphQL call fails
-	if symbol.Data.Block.Call.Status != 1 {
+	if symbol.Data.Block.Call.Status != "0x1" {
 		currency := &RosettaTypes.Currency{
 			Symbol:   defaultERC20Symbol,
 			Decimals: int32(decimalsBigInt.Int64()),


### PR DESCRIPTION
Upgrade RPC node to v1.2.3 has breaking changes in GraphQL response.
The block.number returned from GraphQL api is hex, instead of int64.
This requires a Rosetta parsing fix.
This patch provides a workaround: we will now fetch block index by calling a separate  `eth_getBlockByHash` RPC.
Note: this change is not backwards compatible.